### PR TITLE
New script to build releases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,18 +42,13 @@ sudo unzip $HOME/Downloads/Virtual-Playing-Orchestra3-1-wave-files.zip -d /opt/
 sudo unzip $HOME/Downloads/Virtual-Playing-Orchestra3-2-performance-scripts.zip -d /opt/
 ```
 
-Download [virtual-playing-orchestra-template-2.0.0-RC2.zip](https://github.com/michaelwillis/virtual-playing-orchestra-ardour-template/releases/download/2.0.0-RC2/virtual-playing-orchestra-template-2.0.0-RC2.zip)
+Download **FIXME** virtual-playing-orchestra-template.ardour-template-archive
 
-On Linux, extract to `$HOME/.config/ardour5/templates`:
+* In Ardour, from the menu select "Window", "Template Manager".
+* Click "Import"
+* Browse to and select the virtual-playing-orchestra-template.ardour-template-archive file and choose "Open"
+* You should now see the template listed in your "Session Templates". You can rename templates if you want to keep several versions at once.
 
-```
-unzip $HOME/Downloads/virtual-playing-orchestra-template-2.0.0-RC2.zip -d $HOME/.config/ardour5/templates/
-```
-
-On MacOS, extract to `$HOME/Library/Preferences/Ardour5/templates/`:
-```
-unzip $HOME/Downloads/virtual-playing-orchestra-template-2.0.0-RC2.zip -d $HOME/Library/Preferences/Ardour5/templates/
-```
 
 ## Using the template
 
@@ -90,3 +85,7 @@ This was done for simplicity's sake. Everybody will have different opinions abou
 **Why isn't there a piano?**
 
 People are very opinionated about which sampled piano they want to use, and Virtual Playing Orchestra does not include one for that very reason. Pick your preference of piano and use it.
+
+**Why doesn't it set up any of the SFZ files? Nothing works!**
+
+First, check that you have installed the Virtual Playing Orchestra library into /opt/. Secondly, make sure you use the packaged template archive and load it using the Template Manager, per the instructions above. If you want to use the git repository directly, you will need to fix the filepath for the plugin state files in the template - the setup.sh script can do that for you, and can package the template for release, too. It's currently only tested on Linux, but should work on MacOS, too. You don't need to worry about any of this if you just download the released template archive per the instructions above.

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+# This script is to help when developing or packaging the template.
+#
+# Ash Gittins <ash@ajg.net.au>
+#
+# The template file has to have the full path to the state directories in it when
+# Ardour loads it. This is a problem if you are moving the template to another
+# machine (or user account). Ardour has a packaged template format (the templates
+# folder is simply tar'd up with xz compression (-J) and any instance of the full
+# path in template-dir="" is replaced with "$TEMPLATEDIR", so this script can
+# build a template archive for easy distribution, which the user can then simply
+# import into Ardour through "Window", "Template Manager", "Import".
+#
+# This script is tested on Linux, but *should* work on MacOS as well.
+#
+TEMPLATENAME="Virtual Playing Orchestra"
+TEMPLATEFILE="$TEMPLATENAME.template"
+
+mungepath() {
+	# call with $1 as the template file to modify and $2 as the new directory/token
+	if [ -e "$1" ]; then
+		mv "$1" "$1.backup"
+		cat "$1.backup" | sed -e "s#template-dir=.*$TEMPLATENAME#template-dir=\"$2/$TEMPLATENAME#g" > "$1"
+	else
+		echo "Missing $1!"
+		exit 3
+	fi
+}
+
+case "$1" in
+  build)
+	if [ -e templates ]; then
+		echo "There is already a templates directory - please remove it." >&2
+		exit 5
+	else
+		echo "Building new archive..." >&2
+		if [ ! -e build ]; then mkdir build; fi
+		if [ ! -e build/templates ]; then mkdir build/templates; fi
+		cp -r "$TEMPLATENAME" build/templates/
+		mungepath "build/templates/$TEMPLATENAME/$TEMPLATEFILE" '$TEMPLATEDIR'
+		cd build
+		tar cJf "$TEMPLATENAME.ardour-template-archive" templates
+		cd ..
+		echo "Done. New template archive is in build/$TEMPLATENAME.ardour-template-archive" >&2
+	fi
+		;;
+  generic)
+        echo "Replacing template dir with '\$TEMPLATEDIR'" >&2
+	mungepath "$TEMPLATENAME/$TEMPLATEFILE" '$TEMPLATEDIR'
+        ;;
+  local)
+        echo "Setting templatedir to local system..."
+	mungepath "$TEMPLATENAME/$TEMPLATEFILE" "$(pwd)"
+        ;;
+  *)
+        echo "Usage: $0	[local|generic|build]" >&2
+	echo "" >&2
+	echo "  build:" >&2
+	echo "    This creates a new template archive that you can import directly" >&2
+	echo "    into Ardour. (Look in the 'build' directory). This is very likely" >&2
+	echo "    exactly what you want." >&2
+	echo "  local:" >&2
+	echo "    update the template file with the full path on your local system." >&2
+	echo "    this may or may not be what you want." >&2
+	echo "  generic:" >&2
+	echo "    updates the template with '$TEMPLATEDIR' ready to be archived. This" >&2
+	echo "    is even less likely to be what you want." >&2
+	exit 3
+        ;;
+esac
+

--- a/setup.sh
+++ b/setup.sh
@@ -41,8 +41,9 @@ case "$1" in
 		mungepath "build/templates/$TEMPLATENAME/$TEMPLATEFILE" '$TEMPLATEDIR'
 		cd build
 		tar cJf "$TEMPLATENAME.ardour-template-archive" templates
+		tar cJf "$TEMPLATENAME.tar.xz" templates
 		cd ..
-		echo "Done. New template archive is in build/$TEMPLATENAME.ardour-template-archive" >&2
+		echo "Done. New template archive is in build/$TEMPLATENAME.ardour-template-archive (for Ardour6) and build/$TEMPLATENAME.tar.xz (for Ardour5)" >&2
 	fi
 		;;
   generic)


### PR DESCRIPTION
 setup.sh will build new template-archive files for
 direct importing into Ardour (fixing issue #5) and
 can be used for "localizing" the raw template to other
 machines or user accounts.